### PR TITLE
Modified settings path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ if(WIN32)
     install(TARGETS meteordemod DESTINATION ${CMAKE_INSTALL_PREFIX})
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources/ DESTINATION ${CMAKE_INSTALL_PREFIX}/resources)
 else()
-    install(TARGETS meteordemod DESTINATION bin)
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources/ DESTINATION $ENV{HOME}/meteordemod)
+    install(TARGETS meteordemod DESTINATION bin COMPONENT binaries)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources/ DESTINATION $ENV{HOME}/.config/meteordemod COMPONENT config
+    USE_SOURCE_PERMISSIONS
+    )
 endif()

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -137,7 +137,7 @@ std::string Settings::getResourcesPath() const
     return std::string(path) + "\\resources\\";
 #else
     struct passwd *pw = getpwuid(getuid());
-    return std::string(pw->pw_dir) + "/meteordemod/";
+    return std::string(pw->pw_dir) + "/.config/meteordemod/";
 #endif
 }
 


### PR DESCRIPTION
Hi,
in Linux it is common to have configuration files stored in `$HOME/.config/<program>`.
This PR changes the config path from `$HOME/meteordemod` to  `$HOME/.config/meteordemod` .

By the way: The config files created will be owned by `root` and are unwritable for the user, but CMake seems to not supply an easy way to fix that ¯\_(ツ)_/¯