### PR TITLE
Small change

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,11 +34,6 @@ make -j4
 sudo make install
 ```
 
-The other two dependencies can be downloaded from git with command:
-
-```git submodule update --init --recursive ``` 
-
-
 ## Build and install from sources
 For the development QT creator is used, but the qmake is maintained only for windows.
 

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ cd MeteorDemod
 git submodule update --init --recursive
 mkdir build && cd build
 cmake ../
-make
+make -j4
 sudo make install
 ```
 


### PR DESCRIPTION
I've added four cores to compile MeteorDemod and removed a section from OpenCV how-to-install guide since I think that's not needed there, but in the MeteorDemod compilation section which you've already listed in the commands necessary for installing.